### PR TITLE
Remove 'defer' package from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ colorama==0.4.4
 contexttimer==0.3.3
 cryptography==41.0.5
 dbus-python==1.2.18
-defer==1.0.6
 distlib==0.3.7
 distro==1.7.0
 distro-info==1.1+ubuntu0.2


### PR DESCRIPTION
This pull request removes the 'defer' package from the requirements.txt file. The 'defer' package is no longer needed and removing it will simplify the project dependencies.